### PR TITLE
TBUG-7276: granular permission opening

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-image-picker-multiple",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Multiple image selecting package for React Native using Expo FileSystem",
   "main": "index.js",
   "scripts": {

--- a/src/ImageBrowser.js
+++ b/src/ImageBrowser.js
@@ -40,12 +40,16 @@ export default class ImageBrowser extends React.Component {
   }
 
   getPermissionsAsync = async () => {
-    const { status: camera } =
-      await ImagePicker.requestCameraPermissionsAsync();
-    const { status: cameraRoll } =
-      await ImagePicker.requestMediaLibraryPermissionsAsync();
+    const { status: camera } = await ImagePicker.requestCameraPermissionsAsync(
+      false,
+      []
+    );
+    const { status: cameraRoll } = await MediaLibrary.requestPermissionsAsync(
+      false,
+      []
+    );
     const { status: requestPermissions } =
-      await MediaLibrary.requestPermissionsAsync();
+      await MediaLibrary.requestPermissionsAsync(false, []);
 
     this.setState({
       hasCameraPermission: camera === "granted",


### PR DESCRIPTION
update to stop android devices with API 33+ to show intermediate modal to select granular images